### PR TITLE
fix plot_mesh colouring again

### DIFF
--- a/R/scr_data.R
+++ b/R/scr_data.R
@@ -176,7 +176,8 @@ ScrData <- R6Class("ScrData",
           name <- ""
         }
         if (is.factor(var)) nbreaks <- nlevels(var)
-        mesh$fvar <- cut(as.numeric(var), breaks = nbreaks)
+        fvar <- cut(as.numeric(var), breaks = nbreaks)
+        mesh$fvar <- fvar
       }
       if (is.factor(var)) {
         plt <- ggplot(meshdat) + geom_point(aes(x = x, y = y, col = fvar), ...) + 


### PR DESCRIPTION
Fixes small change in plot_mesh. Plot call uses levels(fvar) but only mesh$fvar was constructed. 